### PR TITLE
:recycle: Be independent of Node types

### DIFF
--- a/deck.ts
+++ b/deck.ts
@@ -1,5 +1,5 @@
 import type { Result } from "./deps/scrapbox.ts";
-import Parser from "./deps/papaparse.ts";
+import { parse } from "./deps/csv.ts";
 import type { Deck } from "./deps/deno-anki.ts";
 
 /** deckデータの書式が不正だったときに投げるエラー */
@@ -9,8 +9,8 @@ export interface InvalidDeckError {
 }
 
 export const parseDeck = (csv: string): Result<Deck, InvalidDeckError> => {
-  const { data } = Parser.parse<[string, string]>(csv);
-  const csvData = new Map<string, string>(data);
+  const data = parse(csv);
+  const csvData = new Map<string, string>(data.map(([f, s]) => [f, s]));
   const name = csvData.get("name");
   if (!name) return { ok: false, value: makeError("Deck name not found.") };
   const id_ = csvData.get("id");

--- a/deps/csv.ts
+++ b/deps/csv.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.178.0/encoding/csv.ts";

--- a/deps/papaparse.ts
+++ b/deps/papaparse.ts
@@ -1,1 +1,0 @@
-export { default } from "https://esm.sh/papaparse@5.3.2";

--- a/noteType.ts
+++ b/noteType.ts
@@ -1,5 +1,5 @@
 import type { Result } from "./deps/scrapbox.ts";
-import Parser from "./deps/papaparse.ts";
+import { parse } from "./deps/csv.ts";
 import type { NoteType } from "./deps/deno-anki.ts";
 
 /** note typeデータの書式が不正だったときに投げるエラー */
@@ -11,8 +11,8 @@ export interface InvalidNoteTypeError {
 export const parseNoteType = (
   csv: string,
 ): Result<NoteType, InvalidNoteTypeError> => {
-  const { data } = Parser.parse<[string, string]>(csv);
-  const csvData = new Map<string, string>(data);
+  const data = parse(csv);
+  const csvData = new Map<string, string>(data.map(([f, s]) => [f, s]));
   const name = csvData.get("name");
   if (!name) {
     return { ok: false, value: makeError("Note Type name not found.") };


### PR DESCRIPTION
papaparseをesm.sh経由で使うとnodeに依存してしまう
このため、`deno bundle`が機能しなくなってしまった

対策として、https://deno.land/std/encoding/csv.ts を使うようにした